### PR TITLE
add uploadStream method to get full compatibility with strapi v4.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,48 @@ module.exports = {
             resolve();
           })
       }),
+      uploadStream(file) {
+        if (!file.stream) {
+          return Promise.reject(new Error("Missing file stream"));
+        }
+        const { stream: stream$1 } = file;
 
+        let prom = new Promise((resolve, reject) => {
+          const _buf = [];
+          stream$1.on("data", (chunk) => _buf.push(chunk));
+          //Mount the buffer from stream to send via api
+          stream$1.on("end", () => resolve(Buffer.concat(_buf)));
+          stream$1.on("error", (err) => reject(err));
+        })
+
+        return new Promise((resolve, reject) => {
+          prom.then((buf) => {
+            file.hash = crypto.createHash('md5').update(file.hash).digest("hex");
+            //--- Upload the file into storage
+            supabase.storage
+              .from(bucket)
+              .upload(
+                getKey({ directory, file }),
+                // file, // or Buffer.from(file.buffer, "binary"),
+                Buffer.from(buf, "binary"), // or file
+                { cacheControl: 'public, max-age=31536000, immutable', upsert: true, contentType: file.mime }
+              )
+              .then(({ data, error: error1 }) => {
+                if (error1) return reject(error1);
+                const { publicURL, error: error2 } = supabase.storage
+                  .from(bucket)
+                  .getPublicUrl(getKey({ directory, file }))
+                if (error2) return reject(error2);
+                file.url = publicURL;
+                resolve();
+              })
+          }).catch((err) => {
+            reject(err)
+          })
+        })
+
+
+      },
       delete: (file, customParams = {}) => new Promise((resolve, reject) => {
         //--- Delete the file fromstorage the space
         supabase.storage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-provider-upload-supabase",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Supabase storage provider for Strapi upload plugin",
   "homepage": "http://strapi.io",
   "keywords": [


### PR DESCRIPTION
This commit resolves the problem on try to upload a logo to strapi and get a 500 error.

The method receives the stream file and converts to Buffer, then send via api to provider.